### PR TITLE
fix: capture err on intermediate retry attempts via EVENT_TEST_RETRY

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
 // -----------------------------------------------------------------------------
 const redis = require("redis");
 const crypto = require("crypto");
-const { Runner } = require("mocha");
 
 const GRANULARITY = {
   TEST: "test",
@@ -38,12 +37,7 @@ let g_capture = { stdout: null, stderr: null };
 // Cache errors from intermediate retry attempts. Mocha only sets test.err via
 // the reporter on the final EVENT_TEST_FAIL; for non-final retries it emits
 // EVENT_TEST_RETRY instead and never stores the error on the test object.
-// We bridge that event through process so mochaGlobalSetup (which has the
-// Runner as `this`) can forward it to afterEach (which doesn't).
 const g_retryErrors = new Map();
-process.on('mocha:retry', (test, err) => {
-  g_retryErrors.set(test.fullTitle(), err);
-});
 
 // -----------------------------------------------------------------------------
 // getTestPath
@@ -119,11 +113,10 @@ function captureStream(stream) {
 // Initialize redis once before the tests
 // -----------------------------------------------------------------------------
 exports.mochaGlobalSetup = async function () {
-  // `this` is the Mocha Runner — forward retry events so afterEach can read
-  // the error from non-final retry attempts (Mocha never sets test.err for
-  // those, only for the final EVENT_TEST_FAIL via the base reporter).
+  // `this` is the Mocha Runner — store errors from non-final retry attempts
+  // so afterEach can record them (Mocha never sets test.err for those).
   this.on('retry', (test, err) => {
-    process.emit('mocha:retry', test, err);
+    g_retryErrors.set(test.fullTitle(), err);
   });
   if (g_mochaVerbose) {
     const redisNoCredentials = g_redisAddress.replace(

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------------
 const redis = require("redis");
 const crypto = require("crypto");
+const { Runner } = require("mocha");
 
 const GRANULARITY = {
   TEST: "test",
@@ -33,6 +34,16 @@ if (g_granularity !== GRANULARITY.TEST) {
 let g_redis = null;
 
 let g_capture = { stdout: null, stderr: null };
+
+// Cache errors from intermediate retry attempts. Mocha only sets test.err via
+// the reporter on the final EVENT_TEST_FAIL; for non-final retries it emits
+// EVENT_TEST_RETRY instead and never stores the error on the test object.
+// We bridge that event through process so mochaGlobalSetup (which has the
+// Runner as `this`) can forward it to afterEach (which doesn't).
+const g_retryErrors = new Map();
+process.on('mocha:retry', (test, err) => {
+  g_retryErrors.set(test.fullTitle(), err);
+});
 
 // -----------------------------------------------------------------------------
 // getTestPath
@@ -108,6 +119,12 @@ function captureStream(stream) {
 // Initialize redis once before the tests
 // -----------------------------------------------------------------------------
 exports.mochaGlobalSetup = async function () {
+  // `this` is the Mocha Runner — forward retry events so afterEach can read
+  // the error from non-final retry attempts (Mocha never sets test.err for
+  // those, only for the final EVENT_TEST_FAIL via the base reporter).
+  this.on('retry', (test, err) => {
+    process.emit('mocha:retry', test, err);
+  });
   if (g_mochaVerbose) {
     const redisNoCredentials = g_redisAddress.replace(
       /\/\/[^@]*@/,
@@ -227,7 +244,10 @@ exports.mochaHooks = {
       // Error objects cannot be properly serialized with stringify, thus
       // we need to use this hack to make it look like a normal object.
       // Hopefully this should work as well with other sort of objects
-      const err = this.currentTest.err || null;
+      const err = this.currentTest.err
+        || g_retryErrors.get(this.currentTest.fullTitle())
+        || null;
+      g_retryErrors.delete(this.currentTest.fullTitle());
       const errObj = JSON.parse(
         JSON.stringify(err, Object.getOwnPropertyNames(err || {}))
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mocha-distributed",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mocha-distributed",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "MIT",
       "dependencies": {
         "redis": "^4.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-distributed",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Run multiple mocha suites and tests in parallel, from different processes and different machines. Results available on a redis database.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run multiple mocha suites and tests in parallel, from different processes and different machines. Results available on a redis database.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha test/test-retry.js"
   },
   "keywords": [
     "mocha",

--- a/test/test-retry.js
+++ b/test/test-retry.js
@@ -1,0 +1,142 @@
+// -----------------------------------------------------------------------------
+// test/test-retry.js
+//
+// Mocha test suite verifying that mocha-distributed records err, stdout and
+// stderr on ALL retry attempts, not just the last one.
+//
+// Run with: mocha test/test-retry.js
+// -----------------------------------------------------------------------------
+'use strict';
+
+const assert = require('assert');
+const Mocha  = require('mocha/lib/mocha');
+const Suite  = require('mocha/lib/suite');
+const Test   = require('mocha/lib/test');
+
+// -----------------------------------------------------------------------------
+// Mock redis helpers
+// -----------------------------------------------------------------------------
+const redisResolved = require.resolve('redis');
+
+const mockMulti = (writtenResults) => () => {
+  const cmds = [];
+  const chain = {
+    set:    (...a) => { cmds.push(['set',    ...a]); return chain; },
+    get:    (...a) => { cmds.push(['get',    ...a]); return chain; },
+    rPush:  (...a) => {
+      cmds.push(['rPush', ...a]);
+      writtenResults.push(JSON.parse(a[1]));
+      return chain;
+    },
+    expire: (...a) => { cmds.push(['expire', ...a]); return chain; },
+    incr:   (...a) => { cmds.push(['incr',   ...a]); return chain; },
+    exec: async () => {
+      // beforeEach pipeline: SET NX + GET — this runner always wins ownership
+      if (cmds[0] && cmds[0][0] === 'set') {
+        return [null, process.env.MOCHA_DISTRIBUTED_RUNNER_ID];
+      }
+      // afterEach pipeline: rPush + expire + incr + expire
+      return [1, 1, 1, 1];
+    }
+  };
+  return chain;
+};
+
+function injectMockRedis(writtenResults) {
+  require.cache[redisResolved] = {
+    id:       redisResolved,
+    filename: redisResolved,
+    loaded:   true,
+    exports:  {
+      createClient: () => ({
+        on:      () => {},
+        connect: async () => {},
+        quit:    async () => {},
+        multi:   mockMulti(writtenResults),
+      })
+    },
+  };
+}
+
+function restoreRedis() {
+  delete require.cache[redisResolved];
+}
+
+function loadFreshLib() {
+  const libPath = require.resolve('../index.js');
+  delete require.cache[libPath];
+  return require('../index.js');
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+describe('mocha-distributed', function () {
+
+  describe('retry attempt recording', function () {
+    let writtenResults;
+    let lib;
+
+    before(function () {
+      writtenResults = [];
+      injectMockRedis(writtenResults);
+
+      process.env.MOCHA_DISTRIBUTED              = 'redis://mock';
+      process.env.MOCHA_DISTRIBUTED_EXECUTION_ID = 'test-exec-retry';
+      process.env.MOCHA_DISTRIBUTED_RUNNER_ID    = 'runner-test';
+
+      lib = loadFreshLib();
+    });
+
+    after(function () {
+      restoreRedis();
+      delete require.cache[require.resolve('../index.js')];
+    });
+
+    it('records err, stdout and stderr on every retry attempt', async function () {
+      this.timeout(10000);
+
+      // Build the inner mocha instance with a flaky test that fails on
+      // attempts 0 and 1, and passes on attempt 2
+      const m = new Mocha({ reporter: 'min' });
+      m.rootHooks(lib.mochaHooks);
+      m.globalSetup([lib.mochaGlobalSetup]);
+      m.globalTeardown([lib.mochaGlobalTeardown]);
+
+      const suite = Suite.create(m.suite, 'retry-suite');
+      suite.retries(2);
+
+      let attempt = 0;
+      suite.addTest(new Test('flaky-test', function () {
+        attempt++;
+        console.log('stdout from attempt ' + attempt);
+        console.error('stderr from attempt ' + attempt);
+        if (attempt < 3) throw new Error('intentional failure on attempt ' + attempt);
+      }));
+
+      await new Promise(resolve => m.run(resolve));
+
+      // Sort by retryAttempt for stable assertions
+      const results = writtenResults.slice().sort((a, b) => a.retryAttempt - b.retryAttempt);
+
+      assert.strictEqual(results.length, 3, '3 results written to Redis (one per attempt)');
+
+      // Attempts 0 and 1: failed, err populated, stdout and stderr present
+      for (const i of [0, 1]) {
+        const r = results[i];
+        assert.strictEqual(r.retryAttempt, i,             `attempt ${i}: retryAttempt`);
+        assert.strictEqual(r.state, 'failed',             `attempt ${i}: state`);
+        assert.ok(r.err && r.err.message,                 `attempt ${i}: err.message should be set`);
+        assert.ok(r.stdout.includes(`attempt ${i + 1}`), `attempt ${i}: stdout`);
+        assert.ok(r.stderr.includes(`attempt ${i + 1}`), `attempt ${i}: stderr`);
+      }
+
+      // Attempt 2: passed, stdout and stderr present
+      const r2 = results[2];
+      assert.strictEqual(r2.retryAttempt, 2,    'attempt 2: retryAttempt');
+      assert.strictEqual(r2.state, 'passed',     'attempt 2: state');
+      assert.ok(r2.stdout.includes('attempt 3'), 'attempt 2: stdout');
+      assert.ok(r2.stderr.includes('attempt 3'), 'attempt 2: stderr');
+    });
+  });
+});


### PR DESCRIPTION
Mocha only sets test.err via the base reporter on EVENT_TEST_FAIL (the final failed attempt). For non-final retries it emits EVENT_TEST_RETRY instead and never stores the error on the test object.

Bridge the Runner 'retry' event (available in mochaGlobalSetup where this === Runner) through process to a module-level Map, then read that Map as a fallback in afterEach.

Also adds a Mocha test suite (test/test-retry.js) that verifies err, stdout and stderr are recorded on every retry attempt, and fixes the test script in package.json to invoke mocha rather than node.