### PR TITLE
fix: skip duplicate-titled tests instead of running them twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,14 +178,21 @@ exports.mochaHooks = {
 
     // Atomically set/get the runner id associated to this test. Only the first
     // runner to get there will set the value to its own runner id.
-    const [_, assignedRunnerId] = await g_redis
+    const [setResult, assignedRunnerId] = await g_redis
       .multi()
       .set(testKey, g_runnerId, { EX: g_expirationTime, NX: true })
       .get(testKey)
       .exec();
 
     if (assignedRunnerId !== g_runnerId) {
+      // Another runner owns this test — skip it
       this.currentTest.title += " (skipped by mocha_distributted)";
+      this.skip();
+    } else if (setResult === null && (this.currentTest._currentRetry || 0) === 0) {
+      // This runner owns the key but didn't just claim it, and it's not a retry.
+      // Two tests share the same title — skip the duplicate.
+      console.warn(`[mocha-distributed] WARNING: duplicate test title detected: "${testPath.join(":")}"`);
+      this.currentTest.title += " (duplicate title - skipped by mocha_distributed)";
       this.skip();
     } else {
       g_capture.stdout = captureStream(process.stdout);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run multiple mocha suites and tests in parallel, from different processes and different machines. Results available on a redis database.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/test-retry.js"
+    "test": "mocha test/test-*.js"
   },
   "keywords": [
     "mocha",

--- a/test/test-duplicate-title.js
+++ b/test/test-duplicate-title.js
@@ -1,0 +1,140 @@
+// -----------------------------------------------------------------------------
+// test/test-duplicate-title.js
+//
+// Mocha test suite verifying that when two it() blocks share the same title,
+// only one of them runs and only one result is written to Redis.
+//
+// Run with: mocha test/test-duplicate-title.js
+// -----------------------------------------------------------------------------
+'use strict';
+
+const assert = require('assert');
+const Mocha = require('mocha/lib/mocha');
+const Suite = require('mocha/lib/suite');
+const Test = require('mocha/lib/test');
+
+// -----------------------------------------------------------------------------
+// Mock redis helpers
+// -----------------------------------------------------------------------------
+const redisResolved = require.resolve('redis');
+
+// mockMulti simulates real Redis SET NX behaviour using an in-memory Map:
+//   - First SET NX for a key stores the value and returns 'OK'
+//   - Subsequent SET NX calls for the same key are no-ops and return null
+//   - GET always returns the current owner
+const mockMulti = (writtenResults, redisState) => () => {
+  const cmds = [];
+  const chain = {
+    set: (...a) => { cmds.push(['set', ...a]); return chain; },
+    get: (...a) => { cmds.push(['get', ...a]); return chain; },
+    rPush: (...a) => {
+      cmds.push(['rPush', ...a]);
+      writtenResults.push(JSON.parse(a[1]));
+      return chain;
+    },
+    expire: (...a) => { cmds.push(['expire', ...a]); return chain; },
+    incr: (...a) => { cmds.push(['incr', ...a]); return chain; },
+    exec: async () => {
+      // beforeEach pipeline: SET NX + GET
+      if (cmds[0] && cmds[0][0] === 'set') {
+        const [, key, value] = cmds[0];
+        const existing = redisState.get(key);
+        if (existing === undefined) {
+          redisState.set(key, value);   // SET NX succeeds
+          return ['OK', value];
+        }
+        return [null, existing];        // SET NX fails, return existing owner
+      }
+      // afterEach pipeline: rPush + expire + incr + expire
+      return [1, 1, 1, 1];
+    }
+  };
+  return chain;
+};
+
+function injectMockRedis(writtenResults, redisState) {
+  require.cache[redisResolved] = {
+    id: redisResolved,
+    filename: redisResolved,
+    loaded: true,
+    exports: {
+      createClient: () => ({
+        on: () => { },
+        connect: async () => { },
+        quit: async () => { },
+        multi: mockMulti(writtenResults, redisState),
+      })
+    },
+  };
+}
+
+function restoreRedis() {
+  delete require.cache[redisResolved];
+}
+
+function loadFreshLib() {
+  const libPath = require.resolve('../index.js');
+  delete require.cache[libPath];
+  return require('../index.js');
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+describe('mocha-distributed', function() {
+
+  describe('duplicate title handling', function() {
+    let writtenResults;
+    let redisState;
+    let lib;
+
+    before(function() {
+      writtenResults = [];
+      redisState = new Map();
+      injectMockRedis(writtenResults, redisState);
+
+      process.env.MOCHA_DISTRIBUTED = 'redis://mock';
+      process.env.MOCHA_DISTRIBUTED_EXECUTION_ID = 'test-exec-duplicate';
+      process.env.MOCHA_DISTRIBUTED_RUNNER_ID = 'runner-test';
+
+      lib = loadFreshLib();
+    });
+
+    after(function() {
+      restoreRedis();
+      delete require.cache[require.resolve('../index.js')];
+    });
+
+    it('runs only one of two tests with the same title', async function() {
+      this.timeout(10000);
+
+      // Build the inner mocha instance with two tests sharing the same title
+      const m = new Mocha({ reporter: 'tap' });
+      m.rootHooks(lib.mochaHooks);
+      m.globalSetup([lib.mochaGlobalSetup]);
+      m.globalTeardown([lib.mochaGlobalTeardown]);
+
+      const suite = Suite.create(m.suite, 'duplicate-suite');
+
+      let runs = 0;
+      suite.addTest(new Test('duplicate-title', function() { runs++; }));
+      suite.addTest(new Test('duplicate-title', function() { runs++; }));
+
+      const runner = await new Promise(resolve => m.run(resolve));
+
+      assert.strictEqual(runs, 1,
+        `expected 1 test body execution, got ${runs} (duplicate ran)`);
+
+      assert.strictEqual(writtenResults.length, 1,
+        `expected 1 result written to Redis, got ${writtenResults.length}`);
+
+      // The second test should have been skipped (pending)
+      // runner here is actually the stats object / exit code from m.run;
+      // check pending via the suite's tests directly instead.
+      const tests = suite.tests;
+      const pendingTests = tests.filter(t => t.isPending && t.isPending());
+      assert.strictEqual(pendingTests.length, 1,
+        `expected 1 pending (skipped) test, got ${pendingTests.length}`);
+    });
+  });
+});

--- a/test/test-retry.js
+++ b/test/test-retry.js
@@ -9,16 +9,16 @@
 'use strict';
 
 const assert = require('assert');
-const Mocha  = require('mocha/lib/mocha');
-const Suite  = require('mocha/lib/suite');
-const Test   = require('mocha/lib/test');
+const Mocha = require('mocha/lib/mocha');
+const Suite = require('mocha/lib/suite');
+const Test = require('mocha/lib/test');
 
 // -----------------------------------------------------------------------------
 // Mock redis helpers
 // -----------------------------------------------------------------------------
 const redisResolved = require.resolve('redis');
 
-const mockMulti = (writtenResults) => () => {
+const mockMulti = (writtenResults, redisState) => () => {
   const cmds = [];
   const chain = {
     set:    (...a) => { cmds.push(['set',    ...a]); return chain; },
@@ -31,9 +31,15 @@ const mockMulti = (writtenResults) => () => {
     expire: (...a) => { cmds.push(['expire', ...a]); return chain; },
     incr:   (...a) => { cmds.push(['incr',   ...a]); return chain; },
     exec: async () => {
-      // beforeEach pipeline: SET NX + GET — this runner always wins ownership
+      // beforeEach pipeline: SET NX + GET — simulate real Redis NX behaviour
       if (cmds[0] && cmds[0][0] === 'set') {
-        return [null, process.env.MOCHA_DISTRIBUTED_RUNNER_ID];
+        const [, key, value] = cmds[0];
+        const existing = redisState.get(key);
+        if (existing === undefined) {
+          redisState.set(key, value);   // SET NX succeeds
+          return ['OK', value];
+        }
+        return [null, existing];        // SET NX fails, return existing owner
       }
       // afterEach pipeline: rPush + expire + incr + expire
       return [1, 1, 1, 1];
@@ -42,17 +48,17 @@ const mockMulti = (writtenResults) => () => {
   return chain;
 };
 
-function injectMockRedis(writtenResults) {
+function injectMockRedis(writtenResults, redisState) {
   require.cache[redisResolved] = {
     id:       redisResolved,
     filename: redisResolved,
     loaded:   true,
     exports:  {
       createClient: () => ({
-        on:      () => {},
-        connect: async () => {},
-        quit:    async () => {},
-        multi:   mockMulti(writtenResults),
+        on: () => { },
+        connect: async () => { },
+        quit: async () => { },
+        multi: mockMulti(writtenResults, redisState),
       })
     },
   };
@@ -75,11 +81,13 @@ describe('mocha-distributed', function () {
 
   describe('retry attempt recording', function () {
     let writtenResults;
+    let redisState;
     let lib;
 
     before(function () {
       writtenResults = [];
-      injectMockRedis(writtenResults);
+      redisState = new Map();
+      injectMockRedis(writtenResults, redisState);
 
       process.env.MOCHA_DISTRIBUTED              = 'redis://mock';
       process.env.MOCHA_DISTRIBUTED_EXECUTION_ID = 'test-exec-retry';
@@ -98,7 +106,7 @@ describe('mocha-distributed', function () {
 
       // Build the inner mocha instance with a flaky test that fails on
       // attempts 0 and 1, and passes on attempt 2
-      const m = new Mocha({ reporter: 'min' });
+      const m = new Mocha({ reporter: 'tap' });
       m.rootHooks(lib.mochaHooks);
       m.globalSetup([lib.mochaGlobalSetup]);
       m.globalTeardown([lib.mochaGlobalTeardown]);


### PR DESCRIPTION
Two it() blocks with the same title map to the same Redis key. The second one would find the key already owned by  the same runner and proceed to run, producing duplicate results. Now, if SET NX return null and _currentRetry is 0, the test is skipped with a warning.

Also added a test/test-duplicate-title.js to cover this case.